### PR TITLE
Wsl2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "omd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,6 @@ fn open_in_browser(link: String) {
     #[cfg(target_os = "linux")]
     {
         if check_for_wsl2() {
-            println!("Found wsl2!");
             std::process::Command::new("powershell.exe")
                 .args(&["-c", "start", &link])
                 .spawn()


### PR DESCRIPTION
Hey! 

Really like the project and think it's such a cool concept to learn about and build on. Awesome job.

Found this works smoothly on Windows itself, but I had some issues when trying to run `omd` in a WSL2 environment which this pull request aims to address. 

The first issue had to do with opening the browser, where I would get the following error: 
```sh
Failed to open browser: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
The fix for me here was to check if the linux environment we are in is WSL2 (this could be more robust, but this initial check worked for me) and if so, use `powershell` to start up the browser (`cmd` was showcasing weird behavior). Otherwise, use `xdg-open`. 

The second had to do with watching the markdown file. At least for WSL2, I noticed that there was an issue with reading the file after making one change where I would then get an `Error reading file: No such file or directory (os error 2)` error, and any further changes to the markdown file wouldn't seen or updated in the browser. To be honest I see the same thing happen when I run it on my fully linux laptop as well, but for this pull request I just wanted to focus on the WSL2 stuff.

From what I could tell it seemed similar to this issue: https://github.com/notify-rs/notify/issues/254, where they suggested using `PollWatcher` based on some duration. I found that ended up working for me, and so now if the check for WSL2 is true, `omd` will use `PollWatcher`, and `RecommendedWatcher` otherwise.

Let me know what you think! Happy to change code around to suit what you want. As I mentioned earlier I did notice the watching issue happening on my Linux laptop as well (switching to a `PollWatcher` helped in that case too), but for this PR I just wanted to address the WSL2 stuff so as not to mess with too many things at once. 
