### PR TITLE
Use PollWatcher for Linux in general

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -278,9 +278,9 @@ fn watch_markdown_file(app_state: Arc<AppState>) {
     }
 
     let (tx_notify, rx_notify) = channel();
-    let watcher = if check_for_wsl2() {
+    let watcher = if cfg!(target_os = "linux") {
         // For whatever reason, recommended watcher was erroring out
-        // when used within WSL2
+        // when used within WSL2 or linux (Mint OS 21.2)
         // notify issue https://github.com/notify-rs/notify/issues/254
         // recommended using pollwatcher which worked in my testing
         let mut watcher = PollWatcher::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,7 @@ fn watch_markdown_file(app_state: Arc<AppState>) {
     let (tx_notify, rx_notify) = channel();
     let watcher = if cfg!(target_os = "linux") {
         // For whatever reason, recommended watcher was erroring out
-        // when used within WSL2 or linux (Mint OS 21.2)
+        // when used within WSL2 or linux (tested in Mint OS 21.2)
         // notify issue https://github.com/notify-rs/notify/issues/254
         // recommended using pollwatcher which worked in my testing
         let mut watcher = PollWatcher::new(


### PR DESCRIPTION
Hey again! This is a simple one-liner, but should resolve the issues I was seeing with the `RecommendedWatcher` not working for Linux systems (admittedly only tested on WSL2 and a Mint 21.2 OS).

Error I was seeing was something like this after making a change to a watched markdown file:

```sh
File changed, updating content...                                                                                       │
Error reading file: No such file or directory (os error 2)
File changed, updating content...
```

Afterwards any additional changes and saves to the markdown file would not be noticed and served.

This change would make it so that `PollWatcher` would be used for Linux systems, and `RecommendedWatcher` for Windows and MacOS. That should resolve any issues I was seeing without potentially disrupting what was already working for Windows and MacOS.

Let me know if you forsee any issues with this!