### PR TITLE
changed some of the style.css for code blocks

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -44,6 +44,10 @@ code {
     border-radius: 3px;
 }
 
+pre code {
+    padding: 0;
+}
+
 h4 {
     font-size: 22px;
 }
@@ -92,21 +96,21 @@ table {
     margin-bottom: 25px;
 }
 
-code::-webkit-scrollbar {
+pre:has(code)::-webkit-scrollbar {
     width: 12px;
     height: 12px;
 }
 
-code::-webkit-scrollbar-track {
+pre:has(code)::-webkit-scrollbar-track {
     background: rgba(0, 0, 0, 0);
 }
 
-code::-webkit-scrollbar-thumb {
+pre:has(code)::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color);
     border-radius: 10px;
 }
 
-code::-webkit-scrollbar-corner {
+pre:has(code)::-webkit-scrollbar-corner {
     background: rgba(0, 0, 0, 0);
 }
 


### PR DESCRIPTION
Hey! So as I was using `omd` I noticed a couple oddities with code blocks that should be fixed after some changes to the `src/style.css` file.

# Code Block Padding

The first had to do with padding within a multi-line code block. First line would get padded while all following lines would not, resulting in something like this:

![image](https://github.com/user-attachments/assets/1215c509-ab2e-4fd7-83d3-c88bc7cb9617)

Where the first line is a bit off from the second. To resolve this I added

```css
pre code {
    padding: 0;
}
```

Which fixes the first line padding for `code` tags specifically in a code block (i.e. surrounded by a `pre` tag), leaving other `code` tags untouched and padded normally.

![image](https://github.com/user-attachments/assets/bce78f11-fdf4-4191-972e-7132cd59f809)

# Code Block Vertical Scroll Bar

The second had to do with the vertical scroll bar not appearing if text was too long in a code block, like so:

![image](https://github.com/user-attachments/assets/0a217442-d3af-4075-8f61-87e250e6b346)

I noticed there were lines that were meant to address this, but think they were pointing at the wrong tag, as the scrollbar exists in the `pre` tag and not the `code` tag. After the following changes I was able to then see a scrollbar if there was text overflow in a code block.

```css
pre:has(code)::-webkit-scrollbar {
    width: 12px;
    height: 12px;
}

pre:has(code)::-webkit-scrollbar-track {
    background: rgba(0, 0, 0, 0);
}

pre:has(code)::-webkit-scrollbar-thumb {
    background-color: var(--scrollbar-thumb-color);
    border-radius: 10px;
}

pre:has(code)::-webkit-scrollbar-corner {
    background: rgba(0, 0, 0, 0);
}
```

Which gives us a nice little scrollbar!

![image](https://github.com/user-attachments/assets/4534cba9-5704-435b-9283-cebc33208760)

And those are the changes! Let me know if there is anything you don't like or would want changed instead. 
